### PR TITLE
feat(auction): full auction room — game logic, AI, timer, UI

### DIFF
--- a/src/components/auction/BidTimer.jsx
+++ b/src/components/auction/BidTimer.jsx
@@ -1,0 +1,50 @@
+import { motion } from 'framer-motion';
+
+const SIZE = 80;
+const STROKE = 6;
+const R = (SIZE - STROKE) / 2;
+const CIRC = 2 * Math.PI * R;
+const TIMER_START = 15;
+
+export default function BidTimer({ timer }) {
+  const pct = timer / TIMER_START;
+  const dash = pct * CIRC;
+  const color = timer > 8 ? '#22c55e' : timer > 4 ? '#f59e0b' : '#ef4444';
+
+  return (
+    <div style={{ position: 'relative', width: SIZE, height: SIZE, flexShrink: 0 }}>
+      <svg width={SIZE} height={SIZE} style={{ transform: 'rotate(-90deg)' }}>
+        {/* Track */}
+        <circle
+          cx={SIZE / 2} cy={SIZE / 2} r={R}
+          fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth={STROKE}
+        />
+        {/* Progress */}
+        <motion.circle
+          cx={SIZE / 2} cy={SIZE / 2} r={R}
+          fill="none" stroke={color} strokeWidth={STROKE}
+          strokeLinecap="round"
+          strokeDasharray={CIRC}
+          strokeDashoffset={CIRC - dash}
+          animate={{ strokeDashoffset: CIRC - dash, stroke: color }}
+          transition={{ duration: 0.8, ease: 'linear' }}
+        />
+      </svg>
+      {/* Number */}
+      <div style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '22px',
+        fontWeight: 800,
+        color,
+        letterSpacing: '-0.04em',
+        fontVariantNumeric: 'tabular-nums',
+      }}>
+        {timer}
+      </div>
+    </div>
+  );
+}

--- a/src/components/auction/PlayerCard.jsx
+++ b/src/components/auction/PlayerCard.jsx
@@ -1,0 +1,143 @@
+import { motion } from 'framer-motion';
+
+const ROLE_ICONS = {
+  'batsman':        '🏏',
+  'wicket-keeper':  '🧤',
+  'all-rounder':    '⭐',
+  'bowler':         '🎳',
+};
+
+const CATEGORY_COLORS = {
+  platinum: { glow: '#E5E4E2', text: '#c8c5c0', bg: 'rgba(229,228,226,0.08)' },
+  diamond:  { glow: '#7DD3FC', text: '#7dd3fc', bg: 'rgba(125,211,252,0.08)' },
+  gold:     { glow: '#FFD700', text: '#fbbf24', bg: 'rgba(251,191,36,0.08)'  },
+  silver:   { glow: '#C0C0C0', text: '#9ca3af', bg: 'rgba(156,163,175,0.08)' },
+  emerging: { glow: '#86EFAC', text: '#86efac', bg: 'rgba(134,239,172,0.08)' },
+};
+
+function StatBox({ label, value, highlight }) {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: '2px',
+      padding: '10px 14px',
+      background: 'rgba(255,255,255,0.04)',
+      borderRadius: '10px',
+      border: '1px solid rgba(255,255,255,0.06)',
+      minWidth: '72px',
+    }}>
+      <span style={{
+        fontSize: '18px',
+        fontWeight: 700,
+        color: highlight ? '#60a5fa' : '#fff',
+        letterSpacing: '-0.02em',
+      }}>
+        {value ?? '—'}
+      </span>
+      <span style={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default function PlayerCard({ player, isNew }) {
+  if (!player) return null;
+  const cat = CATEGORY_COLORS[player.category] ?? CATEGORY_COLORS.silver;
+  const s = player.stats;
+  const isBatter = player.role === 'batsman' || player.role === 'wicket-keeper';
+  const isBowler = player.role === 'bowler';
+
+  return (
+    <motion.div
+      key={player.id}
+      initial={isNew ? { opacity: 0, scale: 0.94, y: 20 } : false}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+      style={{
+        background: 'rgba(255,255,255,0.04)',
+        border: `1px solid ${cat.glow}33`,
+        borderRadius: '20px',
+        padding: '28px 24px',
+        backdropFilter: 'blur(20px)',
+        WebkitBackdropFilter: 'blur(20px)',
+        boxShadow: `0 0 40px ${cat.glow}18`,
+        width: '100%',
+        maxWidth: '380px',
+        margin: '0 auto',
+      }}
+    >
+      {/* Category badge */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+        <span style={{
+          fontSize: '11px',
+          fontWeight: 700,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: cat.text,
+          background: cat.bg,
+          padding: '4px 10px',
+          borderRadius: '9999px',
+          border: `1px solid ${cat.glow}44`,
+        }}>
+          {player.category}
+        </span>
+        <span style={{ fontSize: '13px', color: 'rgba(255,255,255,0.4)' }}>
+          {player.nationality === 'Overseas' ? '🌍 Overseas' : '🇵🇰 Pakistani'}
+        </span>
+      </div>
+
+      {/* Player name */}
+      <div style={{ marginBottom: '6px' }}>
+        <h2 style={{
+          fontSize: 'clamp(22px, 4vw, 30px)',
+          fontWeight: 800,
+          color: '#fff',
+          letterSpacing: '-0.03em',
+          margin: 0,
+          lineHeight: 1.1,
+        }}>
+          {player.name}
+        </h2>
+      </div>
+
+      {/* Role */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '24px' }}>
+        <span style={{ fontSize: '14px' }}>{ROLE_ICONS[player.role]}</span>
+        <span style={{
+          fontSize: '13px',
+          fontWeight: 500,
+          color: 'rgba(255,255,255,0.5)',
+          textTransform: 'capitalize',
+        }}>
+          {player.role.replace('-', ' ')}
+          {player.bowlingStyle ? ` · ${player.bowlingStyle}` : ''}
+        </span>
+      </div>
+
+      {/* Stats row */}
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', justifyContent: 'center' }}>
+        <StatBox label="Matches" value={s.pslMatches} />
+        {(isBatter || player.role === 'all-rounder') && (
+          <>
+            <StatBox label="Runs" value={s.runs?.toLocaleString()} highlight />
+            <StatBox label="Avg" value={s.battingAvg} />
+            <StatBox label="SR" value={s.strikeRate} />
+          </>
+        )}
+        {(isBowler || player.role === 'all-rounder') && (
+          <>
+            <StatBox label="Wkts" value={s.wickets} highlight />
+            <StatBox label="Econ" value={s.economy} />
+          </>
+        )}
+        {isBowler && !s.runs && null}
+        {player.role === 'wicket-keeper' && (
+          <StatBox label="HS" value={s.highScore} />
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/auction/TeamPanel.jsx
+++ b/src/components/auction/TeamPanel.jsx
@@ -1,0 +1,143 @@
+import { motion, AnimatePresence } from 'framer-motion';
+
+const ROLE_ICONS = {
+  'batsman':       '🏏',
+  'wicket-keeper': '🧤',
+  'all-rounder':   '⭐',
+  'bowler':        '🎳',
+};
+
+export default function TeamPanel({ team, isUser, isLight }) {
+  const pctLeft = (team.budget / 18) * 100;
+  const c = {
+    text:    isLight ? '#111' : '#fff',
+    muted:   isLight ? '#6b7280' : 'rgba(255,255,255,0.45)',
+    surface: isLight ? 'rgba(0,0,0,0.04)' : 'rgba(255,255,255,0.04)',
+    border:  isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)',
+  };
+  const accentColor = isUser ? '#3b82f6' : '#f59e0b';
+
+  return (
+    <div style={{
+      background: c.surface,
+      border: `1px solid ${c.border}`,
+      borderRadius: '16px',
+      padding: '16px',
+      backdropFilter: 'blur(16px)',
+      WebkitBackdropFilter: 'blur(16px)',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '12px',
+      minWidth: 0,
+      maxHeight: '560px',
+    }}>
+      {/* Header */}
+      <div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <div>
+            <div style={{
+              fontSize: '10px',
+              fontWeight: 700,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              color: accentColor,
+              marginBottom: '2px',
+            }}>
+              {isUser ? 'Your Squad' : 'AI Squad'}
+            </div>
+            <div style={{
+              fontSize: '14px',
+              fontWeight: 700,
+              color: c.text,
+              letterSpacing: '-0.02em',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              maxWidth: '140px',
+            }}>
+              {team.name}
+            </div>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontSize: '16px', fontWeight: 800, color: accentColor, letterSpacing: '-0.03em' }}>
+              {team.budget.toFixed(2)}
+              <span style={{ fontSize: '10px', fontWeight: 600, color: c.muted, marginLeft: '2px' }}>CR</span>
+            </div>
+            <div style={{ fontSize: '10px', color: c.muted }}>{team.squad.length} players</div>
+          </div>
+        </div>
+
+        {/* Budget bar */}
+        <div style={{
+          height: '3px',
+          background: 'rgba(255,255,255,0.08)',
+          borderRadius: '9999px',
+          marginTop: '10px',
+          overflow: 'hidden',
+        }}>
+          <motion.div
+            animate={{ width: `${pctLeft}%` }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+            style={{
+              height: '100%',
+              background: pctLeft > 50 ? accentColor : pctLeft > 25 ? '#f59e0b' : '#ef4444',
+              borderRadius: '9999px',
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Squad list */}
+      <div style={{
+        flex: 1,
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '6px',
+        paddingRight: '2px',
+      }}>
+        <AnimatePresence initial={false}>
+          {team.squad.length === 0 ? (
+            <div style={{ fontSize: '12px', color: c.muted, textAlign: 'center', padding: '16px 0' }}>
+              No players yet
+            </div>
+          ) : (
+            [...team.squad].reverse().map(player => (
+              <motion.div
+                key={player.id}
+                initial={{ opacity: 0, x: isUser ? -12 : 12 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  padding: '7px 10px',
+                  background: 'rgba(255,255,255,0.03)',
+                  border: '1px solid rgba(255,255,255,0.05)',
+                  borderRadius: '8px',
+                }}
+              >
+                <span style={{ fontSize: '13px', flexShrink: 0 }}>{ROLE_ICONS[player.role]}</span>
+                <span style={{
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: c.text,
+                  flex: 1,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}>
+                  {player.name}
+                </span>
+                <span style={{ fontSize: '11px', color: accentColor, fontWeight: 700, flexShrink: 0 }}>
+                  {player.soldPrice?.toFixed(2)}CR
+                </span>
+              </motion.div>
+            ))
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAuction.js
+++ b/src/hooks/useAuction.js
@@ -1,0 +1,191 @@
+import { useReducer, useEffect, useRef, useCallback } from 'react';
+import allPlayers from '../data/players.json';
+import franchises from '../data/franchises.json';
+import auctionConfig from '../data/auctionConfig.json';
+import { generateAITargets, getAIBid, AI_FRANCHISES } from '../utils/aiUtils';
+
+const TIMER_START = auctionConfig.bidTimerSeconds ?? 15;
+const BID_INCREMENTS = auctionConfig.bidIncrements ?? [0.05, 0.1, 0.25, 0.5];
+const CATEGORY_ORDER = auctionConfig.auctionOrder ?? ['platinum','diamond','gold','silver','emerging'];
+
+function buildQueue(players) {
+  return CATEGORY_ORDER.flatMap(cat =>
+    players
+      .filter(p => p.category === cat)
+      .sort(() => Math.random() - 0.5) // shuffle within category
+  );
+}
+
+function pickAIFranchise(userFranchiseId) {
+  const others = AI_FRANCHISES.filter(id => id !== userFranchiseId);
+  return others[Math.floor(Math.random() * others.length)];
+}
+
+function makeInitialState({ franchiseId, teamName }) {
+  const queue = buildQueue(allPlayers);
+  const [currentPlayer, ...rest] = queue;
+  const userFranchise = franchises.find(f => f.id === franchiseId);
+  const aiFranchiseId = pickAIFranchise(franchiseId);
+  const aiFranchise  = franchises.find(f => f.id === aiFranchiseId);
+  const aiTargets = generateAITargets(allPlayers, auctionConfig.franchiseBudget, 'balanced');
+
+  return {
+    phase: 'bidding',           // 'bidding' | 'sold' | 'unsold' | 'done'
+    currentPlayer,
+    queue: rest,
+    currentBid: currentPlayer.basePrice,
+    bidder: null,               // null | 'user' | 'ai'
+    timer: TIMER_START,
+    timerKey: 0,                // increment to reset timer effects
+    bidIncrements: BID_INCREMENTS,
+    soldPlayers: [],            // history
+
+    user: {
+      id: 'user',
+      name: teamName,
+      franchise: userFranchise,
+      budget: auctionConfig.franchiseBudget,
+      squad: [],
+    },
+    ai: {
+      id: 'ai',
+      name: aiFranchise?.name ?? 'AI Team',
+      franchise: aiFranchise,
+      budget: auctionConfig.franchiseBudget,
+      squad: [],
+      targets: aiTargets,
+    },
+  };
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+
+    case 'TICK': {
+      if (state.phase !== 'bidding') return state;
+      const next = state.timer - 1;
+      if (next <= 0) {
+        // Hammer falls
+        return resolveHammer(state);
+      }
+      return { ...state, timer: next };
+    }
+
+    case 'USER_BID': {
+      if (state.phase !== 'bidding') return state;
+      const newBid = Math.round((state.currentBid + action.increment) * 100) / 100;
+      if (newBid > state.user.budget) return state;
+      return {
+        ...state,
+        currentBid: newBid,
+        bidder: 'user',
+        timer: TIMER_START,
+        timerKey: state.timerKey + 1,
+      };
+    }
+
+    case 'AI_BID': {
+      if (state.phase !== 'bidding') return state;
+      if (state.bidder === 'ai') return state;
+      const newBid = action.amount;
+      if (newBid > state.ai.budget) return state;
+      return {
+        ...state,
+        currentBid: newBid,
+        bidder: 'ai',
+        timer: TIMER_START,
+        timerKey: state.timerKey + 1,
+      };
+    }
+
+    case 'NEXT_PLAYER': {
+      if (state.queue.length === 0) {
+        return { ...state, phase: 'done' };
+      }
+      const [currentPlayer, ...rest] = state.queue;
+      return {
+        ...state,
+        phase: 'bidding',
+        currentPlayer,
+        queue: rest,
+        currentBid: currentPlayer.basePrice,
+        bidder: null,
+        timer: TIMER_START,
+        timerKey: state.timerKey + 1,
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+function resolveHammer(state) {
+  if (state.bidder === null) {
+    return { ...state, phase: 'unsold' };
+  }
+  const winner = state.bidder; // 'user' | 'ai'
+  const soldPlayer = { ...state.currentPlayer, soldPrice: state.currentBid, soldTo: winner };
+  const updatedTeam = {
+    ...state[winner],
+    budget: Math.round((state[winner].budget - state.currentBid) * 100) / 100,
+    squad: [...state[winner].squad, soldPlayer],
+  };
+  return {
+    ...state,
+    phase: 'sold',
+    [winner]: updatedTeam,
+    soldPlayers: [...state.soldPlayers, soldPlayer],
+  };
+}
+
+export function useAuction({ franchiseId, teamName }) {
+  const [state, dispatch] = useReducer(reducer, null, () =>
+    makeInitialState({ franchiseId, teamName })
+  );
+
+  // ── Timer ──────────────────────────────────────────────────────────────────
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    if (state.phase !== 'bidding') {
+      clearInterval(timerRef.current);
+      return;
+    }
+    clearInterval(timerRef.current);
+    timerRef.current = setInterval(() => dispatch({ type: 'TICK' }), 1000);
+    return () => clearInterval(timerRef.current);
+  }, [state.phase, state.timerKey]);
+
+  // ── AI bidding ─────────────────────────────────────────────────────────────
+  const aiTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    if (state.phase !== 'bidding') return;
+    if (state.bidder === 'ai') return;
+
+    // AI thinks after a short delay
+    const delay = 1200 + Math.random() * 2000;
+    clearTimeout(aiTimeoutRef.current);
+    aiTimeoutRef.current = setTimeout(() => {
+      const bidAmount = getAIBid(state);
+      if (bidAmount !== null) {
+        dispatch({ type: 'AI_BID', amount: bidAmount });
+      }
+    }, delay);
+
+    return () => clearTimeout(aiTimeoutRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.currentBid, state.bidder, state.phase, state.currentPlayer?.id]);
+
+  // ── Public actions ─────────────────────────────────────────────────────────
+  const userBid = useCallback((increment) => {
+    dispatch({ type: 'USER_BID', increment });
+  }, []);
+
+  const nextPlayer = useCallback(() => {
+    dispatch({ type: 'NEXT_PLAYER' });
+  }, []);
+
+  return { state, userBid, nextPlayer };
+}

--- a/src/pages/Auction.jsx
+++ b/src/pages/Auction.jsx
@@ -1,7 +1,275 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useTheme } from '../contexts/ThemeContext';
+import { useAuction } from '../hooks/useAuction';
+import PlayerCard from '../components/auction/PlayerCard';
+import BidTimer from '../components/auction/BidTimer';
+import TeamPanel from '../components/auction/TeamPanel';
+
 export default function Auction() {
+  const { state: routeState } = useLocation();
+  const navigate = useNavigate();
+  const { theme } = useTheme();
+  const isLight = theme === 'light';
+
+  const franchiseId = routeState?.franchiseId ?? 'lahore-qalandars';
+  const teamName    = routeState?.teamName    ?? 'My Team';
+
+  const { state, userBid, nextPlayer } = useAuction({ franchiseId, teamName });
+  const { phase, currentPlayer, currentBid, bidder, timer, user, ai, bidIncrements, queue } = state;
+
+  const c = {
+    text:   isLight ? '#111' : '#fff',
+    muted:  isLight ? '#6b7280' : 'rgba(255,255,255,0.45)',
+    border: isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)',
+    surface: isLight ? 'rgba(0,0,0,0.04)' : 'rgba(255,255,255,0.04)',
+  };
+
+  const bidderLabel = bidder === 'user' ? user.name : bidder === 'ai' ? ai.name : null;
+  const bidderColor = bidder === 'user' ? '#3b82f6' : bidder === 'ai' ? '#f59e0b' : c.muted;
+
+  // ── Done screen ──────────────────────────────────────────────────────────
+  if (phase === 'done') {
+    return (
+      <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: '60px' }}>
+        <motion.div
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+          style={{ textAlign: 'center', padding: '0 24px' }}
+        >
+          <div style={{ fontSize: '64px', marginBottom: '16px' }}>🏆</div>
+          <h1 style={{ fontSize: '48px', fontWeight: 800, color: c.text, letterSpacing: '-0.04em', margin: '0 0 12px' }}>
+            Auction Complete
+          </h1>
+          <p style={{ color: c.muted, marginBottom: '32px', fontSize: '16px' }}>
+            You acquired <strong style={{ color: c.text }}>{user.squad.length} players</strong> for{' '}
+            <strong style={{ color: '#3b82f6' }}>
+              {(18 - user.budget).toFixed(2)} CR
+            </strong>
+          </p>
+          <div style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
+            <button
+              className="btn-primary"
+              onClick={() => navigate('/results', { state: { user, ai } })}
+            >
+              See Full Results →
+            </button>
+            <button className="btn-ghost" onClick={() => navigate('/')}>
+              Play Again
+            </button>
+          </div>
+        </motion.div>
+      </div>
+    );
+  }
+
+  // ── Main auction room ────────────────────────────────────────────────────
   return (
-    <div>
-      <h1>Auction Room</h1>
+    <div style={{ minHeight: '100vh', paddingTop: '76px', paddingBottom: '40px' }}>
+      <div className="container" style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+
+        {/* ── Top bar: progress ── */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '16px',
+          flexWrap: 'wrap',
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span style={{
+              width: '8px', height: '8px', borderRadius: '50%', background: '#22c55e',
+              boxShadow: '0 0 8px #22c55e',
+              display: 'inline-block',
+              animation: 'pulse 1.5s ease-in-out infinite',
+            }} />
+            <span style={{ fontSize: '12px', fontWeight: 600, color: c.muted, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+              Live Auction
+            </span>
+          </div>
+          <span style={{ fontSize: '13px', color: c.muted }}>
+            {queue.length + 1} players remaining
+          </span>
+        </div>
+
+        {/* ── 3-column layout ── */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0,1fr) minmax(0,1.6fr) minmax(0,1fr)',
+          gap: '16px',
+          alignItems: 'start',
+        }}>
+          {/* Left: user team */}
+          <TeamPanel team={user} isUser isLight={isLight} />
+
+          {/* Centre: player + bid */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            {/* Player card */}
+            <PlayerCard player={currentPlayer} isNew key={currentPlayer?.id} />
+
+            {/* Current bid display */}
+            <div style={{
+              background: c.surface,
+              border: `1px solid ${c.border}`,
+              borderRadius: '16px',
+              padding: '20px 24px',
+              backdropFilter: 'blur(16px)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: '16px',
+            }}>
+              <div>
+                <div style={{ fontSize: '11px', color: c.muted, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: '4px' }}>
+                  Current Bid
+                </div>
+                <motion.div
+                  key={currentBid}
+                  initial={{ scale: 1.15, opacity: 0.6 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  transition={{ duration: 0.25 }}
+                  style={{
+                    fontSize: '36px',
+                    fontWeight: 800,
+                    letterSpacing: '-0.04em',
+                    color: bidderColor,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {currentBid.toFixed(2)}<span style={{ fontSize: '16px', fontWeight: 600, marginLeft: '4px', opacity: 0.7 }}>CR</span>
+                </motion.div>
+                <div style={{ fontSize: '12px', color: bidderColor, marginTop: '2px', fontWeight: 600 }}>
+                  {bidderLabel ? `Leading: ${bidderLabel}` : 'No bids yet'}
+                </div>
+              </div>
+
+              <BidTimer timer={timer} />
+            </div>
+
+            {/* Bid controls */}
+            <div style={{
+              background: c.surface,
+              border: `1px solid ${c.border}`,
+              borderRadius: '16px',
+              padding: '16px',
+              backdropFilter: 'blur(16px)',
+            }}>
+              {/* Raise buttons */}
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '8px', marginBottom: '10px' }}>
+                {bidIncrements.map(inc => {
+                  const newBid = currentBid + inc;
+                  const canBid = newBid <= user.budget && bidder !== 'user';
+                  return (
+                    <motion.button
+                      key={inc}
+                      whileTap={{ scale: 0.95 }}
+                      onClick={() => userBid(inc)}
+                      disabled={!canBid}
+                      style={{
+                        padding: '12px 8px',
+                        borderRadius: '10px',
+                        border: canBid ? '1px solid rgba(59,130,246,0.4)' : '1px solid rgba(255,255,255,0.06)',
+                        background: canBid ? 'rgba(59,130,246,0.12)' : 'rgba(255,255,255,0.03)',
+                        color: canBid ? '#60a5fa' : c.muted,
+                        fontWeight: 700,
+                        fontSize: '13px',
+                        cursor: canBid ? 'pointer' : 'not-allowed',
+                        transition: 'all 0.15s',
+                        letterSpacing: '-0.01em',
+                      }}
+                    >
+                      +{inc} CR
+                    </motion.button>
+                  );
+                })}
+              </div>
+
+              {/* Status hint */}
+              <div style={{ textAlign: 'center', fontSize: '12px', color: c.muted }}>
+                {bidder === 'user'
+                  ? '✅ You are winning — wait for the hammer'
+                  : bidder === 'ai'
+                  ? '🤖 AI is winning — raise to outbid'
+                  : '👆 Place the first bid'}
+              </div>
+            </div>
+          </div>
+
+          {/* Right: AI team */}
+          <TeamPanel team={ai} isUser={false} isLight={isLight} />
+        </div>
+      </div>
+
+      {/* ── Sold / Unsold overlay ── */}
+      <AnimatePresence>
+        {(phase === 'sold' || phase === 'unsold') && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 100,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'rgba(0,0,0,0.75)',
+              backdropFilter: 'blur(8px)',
+            }}
+            onClick={nextPlayer}
+          >
+            <motion.div
+              initial={{ scale: 0.8, y: 24 }}
+              animate={{ scale: 1, y: 0 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+              style={{ textAlign: 'center', padding: '24px' }}
+            >
+              {phase === 'sold' ? (
+                <>
+                  <div style={{ fontSize: '72px', marginBottom: '8px' }}>🔨</div>
+                  <h2 style={{ fontSize: '52px', fontWeight: 800, letterSpacing: '-0.04em', margin: '0 0 8px', color: '#fff' }}>
+                    SOLD!
+                  </h2>
+                  <p style={{ fontSize: '20px', color: 'rgba(255,255,255,0.7)', margin: '0 0 8px' }}>
+                    <strong style={{ color: bidder === 'user' ? '#3b82f6' : '#f59e0b' }}>
+                      {bidder === 'user' ? user.name : ai.name}
+                    </strong>{' '}
+                    won{' '}
+                    <strong style={{ color: '#fff' }}>{currentPlayer?.name}</strong>
+                  </p>
+                  <p style={{ fontSize: '32px', fontWeight: 800, color: bidder === 'user' ? '#3b82f6' : '#f59e0b', letterSpacing: '-0.03em' }}>
+                    {currentBid.toFixed(2)} CR
+                  </p>
+                </>
+              ) : (
+                <>
+                  <div style={{ fontSize: '72px', marginBottom: '8px' }}>❌</div>
+                  <h2 style={{ fontSize: '52px', fontWeight: 800, letterSpacing: '-0.04em', margin: '0 0 8px', color: '#fff' }}>
+                    UNSOLD
+                  </h2>
+                  <p style={{ fontSize: '18px', color: 'rgba(255,255,255,0.6)', margin: 0 }}>
+                    {currentPlayer?.name} goes unsold
+                  </p>
+                </>
+              )}
+              <p style={{ fontSize: '13px', color: 'rgba(255,255,255,0.35)', marginTop: '24px' }}>
+                Tap anywhere to continue
+              </p>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/utils/aiUtils.js
+++ b/src/utils/aiUtils.js
@@ -1,0 +1,116 @@
+/**
+ * Rule-based AI bidding logic (placeholder until Gemini integration).
+ * AI "personalities" determine aggression and squad-building strategy.
+ */
+
+export const AI_FRANCHISES = [
+  'islamabad-united',
+  'karachi-kings',
+  'quetta-gladiators',
+];
+
+// How many of each role the AI wants in its final squad
+const IDEAL_SQUAD = {
+  batsman:        5,
+  'wicket-keeper': 2,
+  'all-rounder':  4,
+  bowler:         5,
+};
+
+// Stat weights for player valuation (higher = more important to AI)
+const STAT_WEIGHTS = {
+  battingAvg:  0.30,
+  strikeRate:  0.20,
+  wickets:     0.25,
+  economy:     0.15,
+  pslMatches:  0.10,
+};
+
+function normalise(value, min, max) {
+  if (max === min) return 0.5;
+  return Math.max(0, Math.min(1, (value - min) / (max - min)));
+}
+
+// Normalisation ranges for PSL-level stats
+const RANGES = {
+  battingAvg:  { min: 5,  max: 50 },
+  strikeRate:  { min: 90, max: 180 },
+  wickets:     { min: 0,  max: 130 },
+  economy:     { min: 6,  max: 12 },  // inverted — lower is better
+  pslMatches:  { min: 5,  max: 100 },
+};
+
+/** Score a player 0–1 based on raw stats */
+function scorePlayer(player) {
+  const s = player.stats;
+  let score = 0;
+
+  score += STAT_WEIGHTS.battingAvg * normalise(s.battingAvg || 0, RANGES.battingAvg.min, RANGES.battingAvg.max);
+  score += STAT_WEIGHTS.strikeRate * normalise(s.strikeRate || 0, RANGES.strikeRate.min, RANGES.strikeRate.max);
+  score += STAT_WEIGHTS.wickets    * normalise(s.wickets    || 0, RANGES.wickets.min,    RANGES.wickets.max);
+  // Economy: lower is better — invert the normalisation
+  score += STAT_WEIGHTS.economy    * (1 - normalise(s.economy || 10, RANGES.economy.min, RANGES.economy.max));
+  score += STAT_WEIGHTS.pslMatches * normalise(s.pslMatches || 0, RANGES.pslMatches.min, RANGES.pslMatches.max);
+
+  return score;
+}
+
+/**
+ * Generate AI target prices for every player before auction starts.
+ * Returns a map: { [playerId]: maxBidInCrore }
+ */
+export function generateAITargets(players, franchiseBudget, personality = 'balanced') {
+  const targets = {};
+  const multiplierRange = {
+    aggressive:   { min: 1.3, max: 2.8 },
+    balanced:     { min: 1.0, max: 2.0 },
+    value:        { min: 0.8, max: 1.6 },
+  }[personality] ?? { min: 1.0, max: 2.0 };
+
+  for (const player of players) {
+    const quality = scorePlayer(player); // 0–1
+    // Better players get a higher multiplier (up to max)
+    const t = 0.5 + quality * 0.5; // remap to 0.5–1.0
+    const multiplier = multiplierRange.min + t * (multiplierRange.max - multiplierRange.min);
+    // Cap: don't bid more than 20% of budget on a single player
+    const maxAllowed = franchiseBudget * 0.20;
+    const raw = player.basePrice * multiplier;
+    // Round to nearest 0.05 CR
+    targets[player.id] = Math.round(Math.min(raw, maxAllowed) * 20) / 20;
+  }
+
+  return targets;
+}
+
+/**
+ * Decide whether AI should bid on the current state.
+ * Returns the new bid amount (in CR) or null if AI passes.
+ */
+export function getAIBid(state) {
+  const { currentPlayer, currentBid, ai, bidIncrements } = state;
+  if (!currentPlayer) return null;
+
+  const target = ai.targets[currentPlayer.id] ?? 0;
+  const squadSize = ai.squad.length;
+  const roleCount = ai.squad.filter(p => p.role === currentPlayer.role).length;
+  const rolesNeeded = IDEAL_SQUAD[currentPlayer.role] ?? 3;
+
+  // Hard pass: AI already winning, squad full, out of budget, or past target
+  if (state.bidder === 'ai') return null;
+  if (squadSize >= 18) return null;
+
+  // Desperately needs this role → willing to go 20% over target
+  const urgencyBonus = roleCount < rolesNeeded * 0.5 ? 1.2 : 1.0;
+  const effectiveTarget = target * urgencyBonus;
+
+  const nextBid = currentBid + (bidIncrements[0] ?? 0.05);
+  if (nextBid > effectiveTarget) return null;
+  if (nextBid > ai.budget) return null;
+
+  // Choose smallest increment that keeps AI above user
+  const increment = bidIncrements.find(inc => currentBid + inc <= effectiveTarget) ?? bidIncrements[0];
+  const bid = Math.round((currentBid + increment) * 20) / 20;
+  if (bid > ai.budget) return null;
+
+  return bid;
+}


### PR DESCRIPTION
## Summary
- **`useAuction` hook** — `useReducer` game state machine: bidding → sold/unsold → next player → done. 15s countdown via `setInterval`, AI bids via `setTimeout` (1.2–3.2s delay)
- **`aiUtils.js`** — stat-weighted player scoring (battingAvg, SR, wickets, economy, matches), generates AI target prices per player upfront, role-need urgency bonuses, personality system (`aggressive` / `balanced` / `value`)
- **`PlayerCard`** — animated entry, category-colored glow ring, role icon, stat boxes adapt by role (batting stats for batsmen, bowling stats for bowlers)
- **`BidTimer`** — SVG circular countdown, color transitions green → amber → red as time runs low
- **`TeamPanel`** — animated budget bar, live squad list with per-player sold prices, slides in on acquisition
- **`Auction` page** — 3-column layout, current bid number bounces on change, 4 raise buttons disabled when you are winning, sold/unsold full-screen overlay (tap to continue)
- Done screen with squad summary + navigate to results

## Test plan
- [ ] Navigate from Home → pick franchise → Start Auction
- [ ] Timer counts down and triggers sold/unsold
- [ ] AI bids after delay and can outbid user
- [ ] Raise buttons disabled when user is already winning
- [ ] Sold overlay shows correct winner and price
- [ ] After all players, done screen appears
- [ ] Budget decrements correctly on purchase

Closes #15