### PR TITLE
fix(cursor): bat diagonal like 🏏, cap side-profile like 🧢

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -260,10 +260,11 @@ body.light .badge {
   padding: 0 24px;
 }
 
-/* ─── Cricket bat cursor ────────────────────────── */
-/* Upright bat SVG — hotspot at blade tip (9, 0) */
+/* ─── Cricket bat cursor (diagonal, like 🏏 emoji) ─ */
+/* Blade: top-right quadrilateral. Handle: bottom-left thin strip. Ball: red circle.
+   Hotspot at blade tip (21, 3). */
 body {
-  cursor: url('data:image/svg+xml,%3Csvg xmlns%3D"http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width%3D"18" height%3D"28" viewBox%3D"0 0 18 28"%3E%3Crect x%3D"3" y%3D"0" width%3D"12" height%3D"18" rx%3D"4" fill%3D"%23D2691E"/%3E%3Crect x%3D"7" y%3D"16" width%3D"4" height%3D"12" rx%3D"2" fill%3D"%238B4513"/%3E%3Cline x1%3D"7" y1%3D"19" x2%3D"11" y2%3D"19" stroke%3D"%235C3317" stroke-width%3D"1.2"/%3E%3Cline x1%3D"7" y1%3D"22" x2%3D"11" y2%3D"22" stroke%3D"%235C3317" stroke-width%3D"1.2"/%3E%3Cline x1%3D"7" y1%3D"25" x2%3D"11" y2%3D"25" stroke%3D"%235C3317" stroke-width%3D"1.2"/%3E%3C%2Fsvg%3E') 9 0, auto;
+  cursor: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpolygon points="18,1 23,6 11,18 6,13" fill="%23D4A56A"/%3E%3Cpolygon points="11,18 6,13 2,21 4,23" fill="%238B5E3C"/%3E%3Ccircle cx="3" cy="20" r="2.5" fill="%23CC2200"/%3E%3C/svg%3E') 21 3, auto;
 }
 
 button, a, [role="button"], label, select { cursor: pointer; }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,16 +5,18 @@ import { useTheme } from '../contexts/ThemeContext';
 import franchises from '../data/franchises.json';
 import auctionConfig from '../data/auctionConfig.json';
 
-/** Build a cricket cap SVG cursor data URI in the franchise's primary color. */
+/**
+ * Build a side-profile cricket cap cursor (like 🧢 emoji):
+ * dome on the left, visor extending right, hotspot at visor tip.
+ */
 function buildCapCursor(color) {
-  // Slightly darken the color for the brim/band by lowering alpha
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="22" viewBox="0 0 28 22">
-    <path d="M2 15 Q2 1 14 1 Q26 1 26 15 Z" fill="${color}"/>
-    <rect x="2" y="13" width="24" height="4" rx="0" fill="${color}dd"/>
-    <ellipse cx="14" cy="18.5" rx="14" ry="3.5" fill="${color}bb"/>
-    <circle cx="14" cy="2.5" r="1.8" fill="rgba(255,255,255,0.45)"/>
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="28" height="18" viewBox="0 0 28 18">
+    <path d="M4 14 Q4 1 13 1 Q21 1 21 14 Z" fill="${color}"/>
+    <path d="M4 14 Q2 14 2 15.5 Q2 17 4 16.5 Z" fill="${color}" fill-opacity="0.7"/>
+    <rect x="3" y="13" width="25" height="3" rx="1.5" fill="${color}" fill-opacity="0.8"/>
+    <circle cx="12" cy="2.5" r="1.5" fill="rgba(255,255,255,0.5)"/>
   </svg>`;
-  return `url('data:image/svg+xml,${encodeURIComponent(svg)}') 14 19, auto`;
+  return `url('data:image/svg+xml,${encodeURIComponent(svg)}') 27 14, auto`;
 }
 
 const fadeUp = {


### PR DESCRIPTION
Redesigns both cursors to match their emoji counterparts.

Bat: diagonal polygon with blade top-right, handle bottom-left, red ball at base.
Cap: side-profile dome + visor extending right, per-franchise color.